### PR TITLE
Oauth layer and Security Config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,11 @@
             <scope>runtime</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-client</artifactId>
+        </dependency>
+
         <!-- Spring Boot Test -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,13 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.5.0</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/com/group1/project3/Config/SecurityConfig.java
+++ b/src/main/java/com/group1/project3/Config/SecurityConfig.java
@@ -1,0 +1,83 @@
+package com.group1.project3.Config;
+
+import com.group1.project3.service.CustomOAuth2UserService;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import java.util.List;
+
+@Configuration
+public class SecurityConfig {
+
+    @Value("${app.frontend.origin:http://locahost:3000}")
+    private String frontendOrigin;
+
+    @Value("${app.frontend.success-url:http://localhost:3000}")
+    private String frontendSuccessUrl;
+
+    @Bean
+    SecurityFilterChain springFilterChain(HttpSecurity http, CustomOAuth2UserService customOAuth2UserService) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(request -> {
+                    CorsConfiguration cfg = new CorsConfiguration();
+                    cfg.setAllowedOrigins(List.of(frontendOrigin));
+                    cfg.setAllowedMethods(List.of("GET","POST","PATCH","DELETE","OPTIONS"));
+                    cfg.setAllowedHeaders(List.of("*"));
+                    cfg.setAllowCredentials(true);
+                    return cfg;
+                }))
+                .authorizeHttpRequests(auth -> auth
+                        // Preflight requests
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+
+                        // Public endpoints
+                        .requestMatchers("/", "/error").permitAll()
+
+                        // OAuth endpoints must be public
+                        .requestMatchers("/oauth2/**", "/login/oauth2/**").permitAll()
+
+                        // Protect your API
+                        .requestMatchers("/api/**").authenticated()
+
+                        // Everything else (adjust as you like)
+                        .requestMatchers(HttpMethod.PATCH, "/user/*/info").hasRole("USER")
+                        .requestMatchers("/user/**").hasRole("ADMIN")
+                        .anyRequest().authenticated()
+                )
+                .oauth2Login(oauth -> oauth
+                        .defaultSuccessUrl(frontendSuccessUrl, true)
+                        .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
+                )
+                .formLogin(AbstractHttpConfigurer::disable)
+                .logout(logout -> logout
+                        .logoutUrl("/api/logout")
+                        .logoutSuccessUrl(frontendOrigin + "/")
+                )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                            response.getWriter().write("""
+                                    {"error": "NOT AUTHENTICATED", "message" : "Authentication required"}
+                                    """
+                            );
+                        })
+                        .accessDeniedHandler((request, response, accessDeniedException) -> {
+                            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                            response.getWriter().write("""
+                                    {"error": "FORBIDDEN", "message" : "Insufficient permissions"}
+                                    """);
+                        })
+                );
+        return http.build();
+    }
+}

--- a/src/main/java/com/group1/project3/Config/SecurityConfig.java
+++ b/src/main/java/com/group1/project3/Config/SecurityConfig.java
@@ -1,6 +1,6 @@
 package com.group1.project3.Config;
 
-import com.group1.project3.service.CustomOAuth2UserService;
+import com.group1.project3.OAuth.CustomOAuth2UserService;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -19,7 +19,7 @@ public class SecurityConfig {
     @Value("${app.frontend.origin:http://locahost:3000}")
     private String frontendOrigin;
 
-    @Value("${app.frontend.success-url:http://localhost:3000}")
+    @Value("http://localhost:8080/swagger-ui.html")
     private String frontendSuccessUrl;
 
     @Bean
@@ -47,11 +47,16 @@ public class SecurityConfig {
                         // Protect your API
                         .requestMatchers("/api/**").authenticated()
 
+                        .requestMatchers("/swagger-ui.html","/swagger-ui/**","/v3/api-docs/**").permitAll()
+
+                        .requestMatchers("/h2-console/**").permitAll()
+
                         // Everything else (adjust as you like)
                         .requestMatchers(HttpMethod.PATCH, "/user/*/info").hasRole("USER")
                         .requestMatchers("/user/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
+                .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.disable()))
                 .oauth2Login(oauth -> oauth
                         .defaultSuccessUrl(frontendSuccessUrl, true)
                         .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))

--- a/src/main/java/com/group1/project3/OAuth/CustomOAuth2UserService.java
+++ b/src/main/java/com/group1/project3/OAuth/CustomOAuth2UserService.java
@@ -1,4 +1,4 @@
-package com.group1.project3.service;
+package com.group1.project3.OAuth;
 
 import com.group1.project3.entity.Permission;
 import com.group1.project3.entity.User;
@@ -10,7 +10,6 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
-import com.group1.project3.OAuth.OAuthUserAttributesResolver;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
@@ -34,6 +33,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService{
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest request) throws OAuth2AuthenticationException {
+        System.out.println("CUSTOM OAUTH SERVICE RAN");
         OAuth2User oauthUser = fetchOAuthUser(request);
         Map<String, Object> attrs = oauthUser.getAttributes();
         String provider = oAuthUserAttributesResolver.resolveProvider(attrs);
@@ -46,10 +46,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService{
                 .getUserNameAttributeName();
 
         if(!StringUtils.hasText(nameAttributeKey)){
-            nameAttributeKey = "github".equals(provider) ? "login" : "sub";
+            nameAttributeKey = "id";
         }
 
-        User user = userRepository.findByOauthProviderAndOAuthSubject(provider, subject)
+        User user = userRepository.findByAuthProviderAndAuthSubject(provider, subject)
                 .map(existingUser -> {
                     Permission desiredPermission = oAuthUserAttributesResolver.resolvePermission(existingUser);
                     if(existingUser.getPermission() != desiredPermission){

--- a/src/main/java/com/group1/project3/OAuth/CustomOidcUserService.java
+++ b/src/main/java/com/group1/project3/OAuth/CustomOidcUserService.java
@@ -1,0 +1,70 @@
+package com.group1.project3.OAuth;
+
+import com.group1.project3.entity.Permission;
+import com.group1.project3.entity.User;
+import com.group1.project3.repository.UserRepository;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Service;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+@Service
+public class CustomOidcUserService extends OidcUserService {
+
+    private final UserRepository userRepository;
+    private final OAuthUserAttributesResolver oAuthUserAttributesResolver;
+
+
+    public CustomOidcUserService(UserRepository userRepository, OAuthUserAttributesResolver oAuthUserAttributesResolver){
+        this.userRepository = userRepository;
+        this.oAuthUserAttributesResolver = oAuthUserAttributesResolver;
+    }
+
+    @Override
+    public OidcUser loadUser(OidcUserRequest request) throws OAuth2AuthenticationException {
+        OidcUser oidcUser = super.loadUser(request);
+
+        Map<String, Object> attrs = oidcUser.getAttributes();
+
+        String provider = "google";
+        String subject = oAuthUserAttributesResolver.resolveSubject(provider, attrs);
+        String email = oidcUser.getEmail();
+        String username = oAuthUserAttributesResolver.resolveUsername(provider, attrs);
+
+        User user = userRepository.findByAuthProviderAndAuthSubject(provider, subject)
+                .map(existingUser -> {
+                    existingUser.setUsername(username);
+                    existingUser.setEmail(email);
+                    existingUser.setOAuthProvider(provider);
+                    existingUser.setOauthSubject(subject);
+                    return userRepository.save(existingUser);
+                })
+                .orElseGet(() -> {
+                    User newUser = new User();
+                    newUser.setUsername(username);
+                    newUser.setEmail(email);
+                    newUser.setOAuthProvider(provider);
+                    newUser.setOauthSubject(subject);
+                    newUser.setPermission(Permission.USER);
+                    return userRepository.save(newUser);
+                });
+
+        Set<GrantedAuthority> authorities = new HashSet<>(oidcUser.getAuthorities());
+        authorities.add(new SimpleGrantedAuthority("ROLE_" + user.getPermission().name()));
+
+        return new DefaultOidcUser(
+                authorities,
+                oidcUser.getIdToken(),
+                oidcUser.getUserInfo(),
+                "sub"
+        );
+    }
+}

--- a/src/main/java/com/group1/project3/controller/AuthController.java
+++ b/src/main/java/com/group1/project3/controller/AuthController.java
@@ -1,0 +1,49 @@
+package com.group1.project3.controller;
+
+import com.group1.project3.entity.User;
+import com.group1.project3.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RestController
+public class AuthController {
+
+    private final UserService userService;
+
+    public AuthController(UserService userService){
+        this.userService = userService;
+    }
+
+    @GetMapping("/api/me")
+    public Map<String, Object> me(@AuthenticationPrincipal OAuth2User user) {
+        User dbUser = userService.getFromOAuth(user);
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("username", dbUser.getUsername());
+        response.put("name", user.getAttribute("name"));
+        response.put("login", user.getAttribute("login"));
+        response.put("email", user.getAttribute("email"));
+        response.put("oauthProvider", dbUser.getOAuthProvider());
+        response.put("role", dbUser.getPermission().name());
+        response.put("authorities", user.getAuthorities().stream()
+                .map(grantedAuthority -> grantedAuthority.getAuthority())
+                .sorted()
+                .collect(Collectors.toList()));
+        response.put("attributes", user.getAttributes());
+        return response;
+    }
+
+    @DeleteMapping("/api/me")
+    public ResponseEntity<Void> deleteCurrentUser(@AuthenticationPrincipal OAuth2User user){
+        User dbUser = userService.getFromOAuth(user);
+        userService.delete(dbUser.getId());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/group1/project3/entity/Application.java
+++ b/src/main/java/com/group1/project3/entity/Application.java
@@ -13,23 +13,27 @@ public class Application {
 
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
-    private UUID userId;
+    private User user;
 
-    @Column(name = "project_id", nullable = false)
-    private UUID projectId;
+    @ManyToOne(optional = false, fetch= FetchType.LAZY)
+    @JoinColumn(name="project_id", nullable = false)
+    private Project project;
 
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "role_id", nullable = false)
+    private Role role;
 
+    @Column(name="status", nullable = false)
     private String status;
 
     public Application() {
     }
 
-    public Application(UUID id, UUID userId, UUID projectId, String status) {
+    public Application(UUID id, User user, Project project, Role role, String status) {
         this.id = id;
-        this.userId = userId;
-        this.projectId = projectId;
+        this.user = user;
+        this.project = project;
+        this.role = role;
         this.status = status;
     }
 
@@ -42,20 +46,24 @@ public class Application {
     }
 
     public UUID getUserId() {
-        return userId;
+        return user.getId();
     }
 
     public void setUserId(UUID userId) {
-        this.userId = userId;
+        user.setId(userId);
     }
 
     public UUID getProjectId() {
-        return projectId;
+        return project.getId();
     }
 
     public void setProjectId(UUID projectId) {
-        this.projectId = projectId;
+        project.setId(projectId);
     }
+
+    public UUID getRoleId(){ return role.getId();}
+
+    public void setRoleId(UUID roleId) { role.setId(roleId);}
 
     public String getStatus() {
         return status;

--- a/src/main/java/com/group1/project3/entity/Project.java
+++ b/src/main/java/com/group1/project3/entity/Project.java
@@ -16,7 +16,7 @@ public class Project {
 
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
-    private UUID userId;
+    private User user;
 
     @Column(nullable = false)
     private String title;
@@ -34,9 +34,9 @@ public class Project {
     public Project() {
     }
 
-    public Project(UUID id, UUID userId, String title, String generalDescription, String type, String county) {
+    public Project(UUID id, User user, String title, String generalDescription, String type, String county) {
         this.id = id;
-        this.userId = userId;
+        this.user = user;
         this.title = title;
         this.generalDescription = generalDescription;
         this.type = type;
@@ -52,11 +52,11 @@ public class Project {
     }
 
     public UUID getUserId() {
-        return userId;
+        return user.getId();
     }
 
     public void setUserId(UUID userId) {
-        this.userId = userId;
+         user.setId(userId);
     }
 
     public String getTitle() {
@@ -90,4 +90,8 @@ public class Project {
     public void setCounty(String county) {
         this.county = county;
     }
+
+    public List<Role> getRoles() { return roles;}
+
+    public void setRoles() {this.roles = roles;}
 }

--- a/src/main/java/com/group1/project3/entity/User.java
+++ b/src/main/java/com/group1/project3/entity/User.java
@@ -14,13 +14,13 @@ public class User {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false, unique = false)
     private String email;
 
     @Column(nullable = false, unique = true)
     private String username;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String password;
 
     @Enumerated(EnumType.STRING)
@@ -31,7 +31,7 @@ public class User {
     private String authProvider;
 
     @Column(name = "oauth_subject")
-    private String oauthSubject;
+    private String authSubject;
 
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -46,12 +46,13 @@ public class User {
     public User() {
     }
 
-    public User(UUID id, String email, String username, String password, String authProvider) {
+    public User(UUID id, String email, String username, String password, String authProvider, String authSubject) {
         this.id = id;
         this.email = email;
         this.username = username;
         this.password = password;
         this.authProvider = authProvider;
+        this.authSubject = authSubject;
     }
 
     public UUID getId() {
@@ -94,9 +95,9 @@ public class User {
         this.authProvider = oAuthProvider;
     }
 
-    public String getOauthSubject() { return oauthSubject; }
+    public String getOauthSubject() { return authSubject; }
 
-    public void setOauthSubject( String oauthSubject) {this.oauthSubject = oauthSubject; }
+    public void setOauthSubject( String oauthSubject) {this.authSubject = oauthSubject; }
 
     public Permission getPermission() {return permission;}
 

--- a/src/main/java/com/group1/project3/entity/UserProfile.java
+++ b/src/main/java/com/group1/project3/entity/UserProfile.java
@@ -13,7 +13,7 @@ public class UserProfile {
 
     @OneToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false, unique = true)
-    private UUID userId;
+    private User user;
 
     private String bio;
 
@@ -23,9 +23,9 @@ public class UserProfile {
     public UserProfile() {
     }
 
-    public UserProfile(UUID id, UUID userId, String bio, String profilePictureUrl) {
+    public UserProfile(UUID id, User user, String bio, String profilePictureUrl) {
         this.id = id;
-        this.userId = userId;
+        this.user = user;
         this.bio = bio;
         this.profilePictureUrl = profilePictureUrl;
     }
@@ -39,11 +39,11 @@ public class UserProfile {
     }
 
     public UUID getUserId() {
-        return userId;
+        return user.getId();
     }
 
     public void setUserId(UUID userId) {
-        this.userId = userId;
+        user.setId(userId);
     }
 
     public String getBio() {

--- a/src/main/java/com/group1/project3/repository/UserRepository.java
+++ b/src/main/java/com/group1/project3/repository/UserRepository.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, UUID> {
-    Optional<User> findByOauthProviderAndOAuthSubject(String oauthProvider, String oauthSubject);
+    Optional<User> findByAuthProviderAndAuthSubject(String oauthProvider, String oauthSubject);
 
     Optional<User> findByUsername(String username);
 

--- a/src/main/java/com/group1/project3/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/group1/project3/service/CustomOAuth2UserService.java
@@ -1,0 +1,80 @@
+package com.group1.project3.service;
+
+import com.group1.project3.entity.Permission;
+import com.group1.project3.entity.User;
+import com.group1.project3.repository.UserRepository;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import com.group1.project3.OAuth.OAuthUserAttributesResolver;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+@Service
+public class CustomOAuth2UserService extends DefaultOAuth2UserService{
+
+    private final UserRepository userRepository;
+    private final OAuthUserAttributesResolver oAuthUserAttributesResolver;
+
+    public CustomOAuth2UserService(
+            UserRepository userRepository,
+            OAuthUserAttributesResolver oAuthUserAttributesResolver
+    ){
+        this.userRepository = userRepository;
+        this.oAuthUserAttributesResolver = oAuthUserAttributesResolver;
+    }
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest request) throws OAuth2AuthenticationException {
+        OAuth2User oauthUser = fetchOAuthUser(request);
+        Map<String, Object> attrs = oauthUser.getAttributes();
+        String provider = oAuthUserAttributesResolver.resolveProvider(attrs);
+        String subject = oAuthUserAttributesResolver.resolveSubject(provider, attrs);
+        String username = oAuthUserAttributesResolver.resolveUsername(provider, attrs);
+        String email = oauthUser.getAttribute("email");
+        String nameAttributeKey = request.getClientRegistration()
+                .getProviderDetails()
+                .getUserInfoEndpoint()
+                .getUserNameAttributeName();
+
+        if(!StringUtils.hasText(nameAttributeKey)){
+            nameAttributeKey = "github".equals(provider) ? "login" : "sub";
+        }
+
+        User user = userRepository.findByOauthProviderAndOAuthSubject(provider, subject)
+                .map(existingUser -> {
+                    Permission desiredPermission = oAuthUserAttributesResolver.resolvePermission(existingUser);
+                    if(existingUser.getPermission() != desiredPermission){
+                        existingUser.setPermission(desiredPermission);
+                    }
+                    existingUser.setUsername(username);
+                    existingUser.setEmail(email);
+                    existingUser.setOAuthProvider(provider);
+                    return userRepository.save(existingUser);
+                })
+                .orElseGet(() -> {
+                    User newUser = new User();
+                    newUser.setUsername(username);
+                    newUser.setEmail(email);
+                    newUser.setOAuthProvider(provider);
+                    newUser.setOauthSubject(subject);
+                    newUser.setPermission(Permission.USER);
+                    return userRepository.save(newUser);
+                });
+
+        Set<GrantedAuthority> authorities = new HashSet<>(oauthUser.getAuthorities());
+        authorities.add(new SimpleGrantedAuthority("ROLE_" + user.getPermission().name()));
+
+        return new DefaultOAuth2User(authorities, oauthUser.getAttributes(), nameAttributeKey);
+    }
+
+    protected OAuth2User fetchOAuthUser(OAuth2UserRequest request){ return super.loadUser(request);}
+}

--- a/src/main/java/com/group1/project3/service/UserService.java
+++ b/src/main/java/com/group1/project3/service/UserService.java
@@ -125,7 +125,7 @@ public class UserService {
         String provider = oAuthUserAttributesResolver.resolveProvider(attrs);
         String subject = oAuthUserAttributesResolver.resolveSubject(provider, attrs);
 
-        return userRepository.findByOauthProviderAndOAuthSubject(provider, subject)
+        return userRepository.findByAuthProviderAndAuthSubject(provider, subject)
                 .orElseThrow( () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Authenticated user not found."));
 
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,3 +24,11 @@ server.port=8080
 # spring.datasource.username=your_username
 # spring.datasource.password=your_password
 # spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+
+spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID}
+spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_SECRET}
+spring.security.oauth2.client.registration.google.scope=openid,email,profile
+
+spring.security.oauth2.client.registration.github.client-id=${GITHUB_CLIENT_ID}
+spring.security.oauth2.client.registration.github.client-secret=${GITHUB_CLIENT_SECRET}
+spring.security.oauth2.client.registration.github.scope=read:user,user:email


### PR DESCRIPTION
# Summary

Designed the oauth layer to handle login on both google and github authentication. Created a security config file to handle redirecting after authentication and defining which endpoints are permitted by all to enter, and which should only be permitted by admins/users and those authenticated. Added swagger-ui to test out if endpoints return proper responses.

# Edited files
-pom.xml
Added dependencies for oauth, swagger, etc.
-application.properties
Mapped google and github oauth credentials with placeholders to env variables configured locally
- .../Config/SecurityConfig.java
Defined public endpoints, authenticated only endpoints, admin permission only endpoints, and user permission only endpoints.
- .../OAuth/CustomOAuth2UserService.java
Mostly just moved it to the proper directory, made a few small changes since google oauth is now handled in a separate class
- .../OAuth/CustomOidcUserService.java
Handles getting an existing user after they authenticate, if it is user's first time authenticating, user is created
- .../Controller/AuthController.java
Defined easy endpoints to test: GET /api/me ; returns logged-in users information
- .../entity/...
Fixed attributes for entities with relationships to ensure that reference attributes are stored as joined columns and are correct type
- .../Repository/UserRepository.java and .../Service/UserService.java
Method name was wrong, fixed it

# Missing

- Tests
- Connection to a firebase database
- UserProfile layer